### PR TITLE
refactor(gitignore): Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+plugins/*


### PR DESCRIPTION
Directory plugins should not be tracked in git, so it was added to the .gitignore file and removed from tracked files.